### PR TITLE
Update docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,7 +34,7 @@ services:
     image: quay.io/coreos/etcd
     command:  etcd
     volumes:
-      - /usr/share/ca-certificates/:/etc/ssl/certs
+      - /usr/local/etc/ssl/certs/:/etc/ssl/certs
     env_file: etcd.env
     networks:
       - galera


### PR DESCRIPTION
changed the path of certs as I am proposing to change from rancher to default boot2docker image. Rancher does not supports swarm anymore and i am working pretty fine with default boot2docker image.